### PR TITLE
fix: PHP 8.2 compatibility and edge case handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,25 @@
 
 ## Fonctionnalités
 
-Amélioration des factures de situation
+Migration des factures de situation du format v1 (cumul) vers le format v2 (delta).
 
 ## Informations
 
-Numéro du module : 43XXX
-Version : 0.0.1
-Dernière mise à jour : JJ/MM/2023
+Numéro du module : 500000
+Version : 0.3
+Dernière mise à jour : 2023
 Éditeur : Progiseize
-Compatibilité : Dolibarr 15.0.0 - 17.0.0
+Compatibilité : Dolibarr 15.0.0 - 19.0.x
 Thème : Eldy Menu
 Licence : GPLv3
-Disponible sûr : Windows - MacOS - Linux
+Disponible sur : Windows - MacOS - Linux
 
 ## Liens
 
 - Support & Assistance : Sur le forum
-- Demo : À venir
-- Documentation : à venir
-- Projet GitHub : [Projet Digirisk](https://github.com/progiseize/facture_situation_migration)
-- Forum : [Forum Digirisk](https://www.dolibarr.fr/forum/t/gif-facture-de-situation/41868)
+- Projet GitHub : [facture_situation_migration](https://github.com/progiseize/facture_situation_migration)
+- Forum : [GIF Facture de situation](https://www.dolibarr.fr/forum/t/gif-facture-de-situation/41868)
 - Wiki : [Wiki](https://wiki.dolibarr.org/index.php?title=GIF_-_Facture_de_situation_2022)
-- Modules à venir
 
 
 ## Traduction

--- a/class/facturesituationmigration.class.php
+++ b/class/facturesituationmigration.class.php
@@ -264,7 +264,7 @@ class FactureSituationMigration
 					dol_syslog('sql='.$sql_insert, LOG_DEBUG, 0, '_situationmigration');
 
 					$res_insert = $this->db->query($sql_insert);
-					if ($res_insert) {$insert_success++;} elseif (!$res_insert && $this->db->db->lasterrno == 'DB_ERROR_RECORD_ALREADY_EXISTS') {
+					if ($res_insert) {$insert_success++;} elseif (!$res_insert && $this->db->lasterrno == 'DB_ERROR_RECORD_ALREADY_EXISTS') {
 						dol_syslog('ID('.$obj->rowid.') already exist, we continue', LOG_DEBUG, 0, '_situationmigration');
 						$insert_exist++;
 					}
@@ -354,7 +354,7 @@ class FactureSituationMigration
 				$this->db->begin();
 
 				$sql_bis = "SELECT";
-				$sql_bis.= " f.rowid as facture_id, f.ref as facture_ref, f.situation_cycle_ref as facture_cycle_ref, f.situation_counter as facture_situation_counter, f.situation_final as facture_situation_final";
+				$sql_bis.= " f.rowid as facture_id, f.ref as facture_ref, f.situation_cycle_ref as facture_cycle_ref, f.situation_counter as facture_situation_counter, f.situation_final as facture_situation_final, YEAR(f.datef) as facture_year";
 				$sql_bis.= " , fd.rowid as ligne_id, fd.situation_percent as ligne_percent, fd.fk_prev_id as ligne_prev_id";
 				$sql_bis.= " , fd.subprice as ligne_subprice, fd.total_ht as ligne_total_ht, fd.total_tva as ligne_total_tva, fd.total_ttc as ligne_total_ttc, fd.special_code as special_code";
 				$sql_bis.= " , fd.multicurrency_subprice as ligne_multicurrency_subprice, fd.multicurrency_total_ht as ligne_multicurrency_total_ht, fd.multicurrency_total_tva as ligne_multicurrency_total_tva, fd.multicurrency_total_ttc as ligne_multicurrency_total_ttc";
@@ -378,7 +378,7 @@ class FactureSituationMigration
 						if (!isset($cycle_array[$obj_bis->facture_situation_counter])) {
 							$cycle_array[$obj_bis->facture_situation_counter] = array(
 								'facture_year' => $obj_bis->facture_year,
-								'situation_final' => $obj_bis->situation_final,
+								'situation_final' => $obj_bis->facture_situation_final,
 								'facture_id' => $obj_bis->facture_id,
 								'facture_ref' => $obj_bis->facture_ref,
 								'lines' => array(),
@@ -406,6 +406,16 @@ class FactureSituationMigration
 					//var_dump('-- CYCLE N°'.$obj->situation_cycle_ref);
 					//var_dump($cycle_array);
 
+					// Si aucune ligne trouvée (factures vides/brouillons sans lignes), on marque tout le cycle comme done
+					if (empty($cycle_array)) {
+						dol_syslog('Cycle '.$obj->situation_cycle_ref.' has no lines (empty drafts), marking all invoices as done', LOG_DEBUG, 0, '_situationmigration');
+						$sql_mark = "UPDATE ".MAIN_DB_PREFIX.$this->table_migration." SET done = 1 WHERE situation_cycle_ref = '".$this->db->escape($obj->situation_cycle_ref)."' AND entity = '".$conf->entity."'";
+						$this->db->query($sql_mark);
+						$nb_update_success++;
+						$this->db->commit();
+						continue;
+					}
+
 					//
 					$facture_update = 0;
 					$facture_update_success = 0;
@@ -413,6 +423,11 @@ class FactureSituationMigration
 
 					// TRI DECROISSANT
 					krsort($cycle_array);
+
+					// Mark done any invoices in this cycle that were lost due to duplicate situation_counter
+					// (cycle_array is keyed by counter, so duplicates overwrite each other)
+					$sql_orphans = "UPDATE ".MAIN_DB_PREFIX.$this->table_migration." SET done = 1 WHERE situation_cycle_ref = '".$this->db->escape($obj->situation_cycle_ref)."' AND entity = '".$conf->entity."' AND rowid NOT IN ('".implode("','", array_column($cycle_array, 'facture_id'))."') AND done = 0";
+					$this->db->query($sql_orphans);
 
 					// print json_encode($cycle_array);exit;
 					// POUR CHAQUE SITUATION DU CYCLE
@@ -443,6 +458,7 @@ class FactureSituationMigration
 							foreach ($cycle_infos['lines'] as $line_id => $line_infos) :
 								//plus facile à suivre, l'id de la ligne sur la facture précédente
 								$fk_prev_id = $line_infos['fk_prev_id'];
+								if (empty($fk_prev_id) || !isset($cycle_array[$cycle_counter_before]['lines'][$fk_prev_id])) { continue; }
 								//et la ligne complète
 								$prev_line_infos = $cycle_array[$cycle_counter_before]['lines'][$fk_prev_id];
 								$prev_facture_ref = $cycle_array[$cycle_counter_before]['facture_ref'];


### PR DESCRIPTION
Tested the module successfully on **Dolibarr 19.0.0** (PHP 8.2, MariaDB 10.5). This PR fixes several issues encountered:

### PHP 8.2 strict mode fixes

- Missing `YEAR(f.datef) as facture_year` in step3 SQL query → undefined property warning
- Wrong alias access: `$obj_bis->situation_final` → should be `$obj_bis->facture_situation_final`
- Invalid `$this->db->db->lasterrno` → should be `$this->db->lasterrno` (DoliDB API)
- Unguarded access to `$cycle_array[$cycle_counter_before]['lines'][$fk_prev_id]` when `fk_prev_id` is empty

### Edge cases causing infinite loop in step3

- Cycles containing only empty drafts (0 lines): `INNER JOIN` returns no rows → nothing is ever marked `done`
- Cycles with duplicate `situation_counter` (e.g. two invoices at counter 3): `cycle_array` keyed by counter loses one invoice, which is never marked `done`

### README

Updated module number, version, compatibility range, and links.